### PR TITLE
Support for importing files as raw strings (like vite)

### DIFF
--- a/packages/core/src/rolldown_plugins.ts
+++ b/packages/core/src/rolldown_plugins.ts
@@ -3,6 +3,7 @@ import { glob } from "tinyglobby";
 
 import { resolve } from "node:path";
 import { cwd } from "node:process";
+import { readFile } from "node:fs/promises";
 import { transform as swcTranform } from "@swc/core";
 import postcss from "postcss";
 
@@ -99,5 +100,18 @@ const handleVendorStyles = async (ctx: PluginContext, path: string) => {
     }
   } catch (error: any) {
     ctx.error(error);
+  }
+};
+
+
+export const rawImportSupport = () => {
+  return {
+    name: 'raw-import-support',
+    async load(id) {
+      if (id.endsWith('?raw')) {
+        const rawContent = await readFile(id.replace('?raw', ''), 'utf8');
+        return `export default \`${rawContent.replace(/`/g, '\\`')}\`;`;
+      }
+    }
   }
 };

--- a/packages/core/src/rolldown_setup.ts
+++ b/packages/core/src/rolldown_setup.ts
@@ -12,7 +12,7 @@ import type {
 } from "rolldown";
 
 import { loadConfig } from "./config/config_handler.ts";
-import { handleVendorFiles } from "./rolldown_plugins.ts";
+import { handleVendorFiles, rawImportSupport } from "./rolldown_plugins.ts";
 import { fancyLogFormater } from "./utils.ts";
 
 const config = await loadConfig();
@@ -50,6 +50,7 @@ export const setupRolldown = () => {
     input: resolve(cwd(), config.bundler.filesystem!.projectFiles!.entryPoint!),
 
     plugins: [
+      rawImportSupport(),
       // @ts-expect-error
       postcss({
         module: false,


### PR DESCRIPTION
This PR adds a tiny plugin to rolldown to support importing from JS/TS a file as a raw string, using [the same syntax supported out-of-the-box by vite](https://vite.dev/guide/assets.html#importing-asset-as-string):
```js
import fileContent from './myFile.txt?raw';
```

My use case for needing this is to load SVG files at build-time so that they can be altered via code (as loading them at runtime has CORS issues), but I feel it would be a nice addition for other potential cases such as loading CSVs or JSONs.