### PR TITLE
feat: add Bun single executable compilation

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -3,7 +3,7 @@ import { program } from "commander";
 import pkg from "../package.json" with { type: "json" };
 const { version, description } = pkg;
 import pico from "picocolors";
-import { runBuild } from "./run_build.ts";
+import { runBuild, runCompile } from "./run_build.ts";
 import { runDev } from "./run_dev.ts";
 import { rm } from "fs/promises";
 import { resolveToProjectRoot } from "./utils.ts";
@@ -13,9 +13,9 @@ program
   .name("weaver")
   .description(
     "\t\t" +
-      pico.bgBlue(pico.bgMagenta(pico.bold("  Thy Weaver  "))) +
-      "\n" +
-      description,
+    pico.bgBlue(pico.bgMagenta(pico.bold("  Thy Weaver  "))) +
+    "\n" +
+    description,
   )
   .version(version);
 
@@ -24,6 +24,13 @@ program
   .description("Build the project to dist/")
   .action(async (_str) => {
     await runBuild();
+  });
+
+program
+  .command("compile")
+  .description("Compile the project to build/")
+  .action(async (_str) => {
+    await runCompile();
   });
 
 program

--- a/packages/core/src/compile_commands.ts
+++ b/packages/core/src/compile_commands.ts
@@ -1,0 +1,44 @@
+import pico from "picocolors";
+import { loadConfig } from "./config/config_handler.ts";
+
+const { bundler } = await loadConfig();
+const { filesystem } = bundler;
+
+export const runBunCompilation = async () => {
+  await Bun.write(filesystem!.dist + "index.ts", `
+    import { Webview } from "webview-bun";
+    const worker = new Worker("./worker.ts");
+    worker.addEventListener("close", () => webview.destroy());
+
+    const webview = new Webview();
+    webview.navigate("http://localhost:3000/");
+    webview.run();
+
+    worker.terminate();
+  `);
+
+  await Bun.write(filesystem!.dist + "worker.ts", `
+    import { serve } from 'bun';
+    import index from './index.html';
+
+    const server = serve({
+      routes: {
+        '/': index,
+      },
+    });
+  `);
+
+  const packageData = JSON.parse(await Bun.file("./package.json").text());
+  await Bun.build({
+    compile: {
+      outfile: packageData.name,
+      windows: {
+        hideConsole: true
+      }
+    },
+    entrypoints: [filesystem!.dist + "index.ts", filesystem!.dist + "worker.ts"],
+    outdir: filesystem!.build,
+    minify: true,
+    sourcemap: true,
+  });
+}

--- a/packages/core/src/config/config_types.ts
+++ b/packages/core/src/config/config_types.ts
@@ -34,6 +34,7 @@ export interface BundlerOptions {
     };
     stagingDir?: string;
     dist?: string;
+    build?: string;
   };
 
   swc?: SWCOptions;

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -26,6 +26,7 @@ export const defaultConfig: ThyWevearOptions = {
         htmlHead: "src/head_content.html",
       },
       stagingDir: resolve(tempFolderPath(), "staging/"),
+      build: "build/",
     },
   },
 };


### PR DESCRIPTION
Hi,
This PR might not be up to your standards, please feel free to modify any part of it !
The main objective was just to offer another (maybe easier) integration using Webview2 than the proposed Tauri, Wails or Electron. A big advantage is using Bun and Webview-bun do not require any extra language or pipeline.

It adds a new command `weaver compile` to compile to an executable using [BunJS](https://bun.com/docs) and [Webview-bun](https://github.com/tr1ckydev/webview-bun).
I took inspiration from both
- [Webview-bun - Bun.serve with webview](https://github.com/tr1ckydev/webview-bun?tab=readme-ov-file#bunserve-with-webview)
- [Bun - Single-file executable](https://bun.com/docs/bundler/executables#single-file-executable)

Here is the breakdown of the operation:
1. Builds the story as usual
2. Adds an `index.ts` file that acts as the entrypoint for Webview-bun
3. Adds a `worker.ts` file that serves the files embedded in the executable
4. Builds the executable using [Bun Bundler](https://bun.com/docs/bundler)

Notes:
- The destination build directory is customizable
- The `index.ts` and `worker.ts` files are added to `dist/` because that makes it easier since all of them are collocating in `dist/`
- I agree, creating `index.ts` and `worker.ts` like this is not ideal but I didn't know where or how you would want to add them for the compilation to work. Let's discuss it.
- I made it so the executable looks for a `/media` folder next to it (like the HTML file looks for the `/media` folder next to it)

Tested manually by creating an empty Thy-Weaver project (using `bun create weaver@latest`). Only tested on Windows.

Limitations:
- Of course Bun is mandatory at runtime to compile the story but it should not be required to build Thy-Weaver itself.
- Users need to specify the `--bun` (eg. `bun --bun run weaver compile`) so `Bun` is defined in the compilation script. I took care of adding an error message in case `--bun` was not used. 
- Webview-bun seems to only be compatible with desktops.
- This PR does not allow to customize the application icon but [Webview-bun - Extras](https://github.com/tr1ckydev/webview-bun?tab=readme-ov-file#extras) has some pointers. (maybe another PR later ?)