### PR TITLE
feat: allow for yaml import

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,84 +1,84 @@
 {
-    "name": "@thy-weaver/core",
-    "version": "1.0.3",
-    "description": "A cli to compile and bundle Twine based stories",
-    "main": "dist/main.js",
-    "types": "dist/main.d.ts",
-    "type": "module",
-    "bin": {
-        "weaver": "dist/cli.js"
+  "name": "@thy-weaver/core",
+  "version": "1.0.3",
+  "description": "A cli to compile and bundle Twine based stories",
+  "main": "dist/main.js",
+  "types": "dist/main.d.ts",
+  "type": "module",
+  "bin": {
+    "weaver": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "weaver": "dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/main.js",
+      "require": "./dist/main.js",
+      "types": "./dist/main.d.ts"
     },
-    "scripts": {
-        "build": "tsdown",
-        "dev": "tsdown --watch",
-        "weaver": "dist/cli.js"
+    "./types": {
+      "types": "./types/index.d.ts"
     },
-    "exports": {
-        ".": {
-            "import": "./dist/main.js",
-            "require": "./dist/main.js",
-            "types": "./dist/main.d.ts"
-        },
-        "./types": {
-            "types": "./types/index.d.ts"
-        },
-        "./plugin_helpers": {
-            "import": "./dist/plugin_helpers.js",
-            "require": "./dist/plugin_helpers.js",
-            "types": "./dist/plugin_helpers.d.ts"
-        }
-    },
-    "files": [
-        "dist",
-        "types"
-    ],
-    "keywords": [
-        "Twine",
-        "Twee",
-        "Twee3",
-        "Tweego"
-    ],
-    "license": "MIT",
-    "homepage": "https://github.com/greatsquare0/thy-weaver/tree/main/packages/core",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/greatsquare0/thy-weaver/tree/main/packages/core"
-    },
-    "bugs": "https://github.com/greatsquare0/thy-weaver/issues",
-    "devDependencies": {
-        "@prettier/plugin-oxc": "^0.0.4",
-        "@tsconfig/node22": "^22.0.2",
-        "@types/fs-extra": "^11.0.4",
-        "@types/node": "^24.0.10",
-        "oxlint": "^1.5.0",
-        "prettier": "^3.6.2",
-        "tsdown": "^0.12.9",
-        "typescript": "^5.8.3"
-    },
-    "dependencies": {
-        "@rollup/plugin-url": "^8.0.2",
-        "@rollup/plugin-yaml": "4.1.2",
-        "@swc/core": "^1.12.9",
-        "browserslist": "^4.25.1",
-        "chokidar": "^4.0.3",
-        "commander": "^14.0.0",
-        "deepmerge-ts": "^7.1.5",
-        "fs-extra": "^11.3.0",
-        "h3": "2.0.0-beta.1",
-        "lightningcss": "^1.30.1",
-        "lilconfig": "^3.1.3",
-        "ora": "catalog:",
-        "picocolors": "catalog:",
-        "postcss": "^8.5.6",
-        "postcss-import": "^16.1.1",
-        "postcss-lightningcss": "^1.0.1",
-        "postcss-loader": "^8.1.1",
-        "postcss-scss": "^4.0.9",
-        "rolldown": "1.0.0-beta.24",
-        "rollup-plugin-postcss": "^4.0.2",
-        "rollup-plugin-swc3": "^0.12.1",
-        "sass": "^1.89.2",
-        "tinyglobby": "catalog:",
-        "tweenode": "^0.3.0"
+    "./plugin_helpers": {
+      "import": "./dist/plugin_helpers.js",
+      "require": "./dist/plugin_helpers.js",
+      "types": "./dist/plugin_helpers.d.ts"
     }
+  },
+  "files": [
+    "dist",
+    "types"
+  ],
+  "keywords": [
+    "Twine",
+    "Twee",
+    "Twee3",
+    "Tweego"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/greatsquare0/thy-weaver/tree/main/packages/core",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/greatsquare0/thy-weaver/tree/main/packages/core"
+  },
+  "bugs": "https://github.com/greatsquare0/thy-weaver/issues",
+  "devDependencies": {
+    "@prettier/plugin-oxc": "^0.0.4",
+    "@tsconfig/node22": "^22.0.2",
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^24.0.10",
+    "oxlint": "^1.5.0",
+    "prettier": "^3.6.2",
+    "tsdown": "^0.12.9",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "@rollup/plugin-url": "^8.0.2",
+    "@rollup/plugin-yaml": "4.1.2",
+    "@swc/core": "^1.12.9",
+    "browserslist": "^4.25.1",
+    "chokidar": "^4.0.3",
+    "commander": "^14.0.0",
+    "deepmerge-ts": "^7.1.5",
+    "fs-extra": "^11.3.0",
+    "h3": "2.0.0-beta.1",
+    "lightningcss": "^1.30.1",
+    "lilconfig": "^3.1.3",
+    "ora": "catalog:",
+    "picocolors": "catalog:",
+    "postcss": "^8.5.6",
+    "postcss-import": "^16.1.1",
+    "postcss-lightningcss": "^1.0.1",
+    "postcss-loader": "^8.1.1",
+    "postcss-scss": "^4.0.9",
+    "rolldown": "1.0.0-beta.24",
+    "rollup-plugin-postcss": "^4.0.2",
+    "rollup-plugin-swc3": "^0.12.1",
+    "sass": "^1.89.2",
+    "tinyglobby": "catalog:",
+    "tweenode": "^0.3.0"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,83 +1,84 @@
 {
-  "name": "@thy-weaver/core",
-  "version": "1.0.3",
-  "description": "A cli to compile and bundle Twine based stories",
-  "main": "dist/main.js",
-  "types": "dist/main.d.ts",
-  "type": "module",
-  "bin": {
-    "weaver": "dist/cli.js"
-  },
-  "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch",
-    "weaver": "dist/cli.js"
-  },
-  "exports": {
-    ".": {
-      "import": "./dist/main.js",
-      "require": "./dist/main.js",
-      "types": "./dist/main.d.ts"
+    "name": "@thy-weaver/core",
+    "version": "1.0.3",
+    "description": "A cli to compile and bundle Twine based stories",
+    "main": "dist/main.js",
+    "types": "dist/main.d.ts",
+    "type": "module",
+    "bin": {
+        "weaver": "dist/cli.js"
     },
-    "./types": {
-      "types": "./types/index.d.ts"
+    "scripts": {
+        "build": "tsdown",
+        "dev": "tsdown --watch",
+        "weaver": "dist/cli.js"
     },
-    "./plugin_helpers": {
-      "import": "./dist/plugin_helpers.js",
-      "require": "./dist/plugin_helpers.js",
-      "types": "./dist/plugin_helpers.d.ts"
+    "exports": {
+        ".": {
+            "import": "./dist/main.js",
+            "require": "./dist/main.js",
+            "types": "./dist/main.d.ts"
+        },
+        "./types": {
+            "types": "./types/index.d.ts"
+        },
+        "./plugin_helpers": {
+            "import": "./dist/plugin_helpers.js",
+            "require": "./dist/plugin_helpers.js",
+            "types": "./dist/plugin_helpers.d.ts"
+        }
+    },
+    "files": [
+        "dist",
+        "types"
+    ],
+    "keywords": [
+        "Twine",
+        "Twee",
+        "Twee3",
+        "Tweego"
+    ],
+    "license": "MIT",
+    "homepage": "https://github.com/greatsquare0/thy-weaver/tree/main/packages/core",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/greatsquare0/thy-weaver/tree/main/packages/core"
+    },
+    "bugs": "https://github.com/greatsquare0/thy-weaver/issues",
+    "devDependencies": {
+        "@prettier/plugin-oxc": "^0.0.4",
+        "@tsconfig/node22": "^22.0.2",
+        "@types/fs-extra": "^11.0.4",
+        "@types/node": "^24.0.10",
+        "oxlint": "^1.5.0",
+        "prettier": "^3.6.2",
+        "tsdown": "^0.12.9",
+        "typescript": "^5.8.3"
+    },
+    "dependencies": {
+        "@rollup/plugin-url": "^8.0.2",
+        "@rollup/plugin-yaml": "4.1.2",
+        "@swc/core": "^1.12.9",
+        "browserslist": "^4.25.1",
+        "chokidar": "^4.0.3",
+        "commander": "^14.0.0",
+        "deepmerge-ts": "^7.1.5",
+        "fs-extra": "^11.3.0",
+        "h3": "2.0.0-beta.1",
+        "lightningcss": "^1.30.1",
+        "lilconfig": "^3.1.3",
+        "ora": "catalog:",
+        "picocolors": "catalog:",
+        "postcss": "^8.5.6",
+        "postcss-import": "^16.1.1",
+        "postcss-lightningcss": "^1.0.1",
+        "postcss-loader": "^8.1.1",
+        "postcss-scss": "^4.0.9",
+        "rolldown": "1.0.0-beta.24",
+        "rollup-plugin-postcss": "^4.0.2",
+        "rollup-plugin-swc3": "^0.12.1",
+        "sass": "^1.89.2",
+        "tinyglobby": "catalog:",
+        "tweenode": "^0.3.0"
     }
-  },
-  "files": [
-    "dist",
-    "types"
-  ],
-  "keywords": [
-    "Twine",
-    "Twee",
-    "Twee3",
-    "Tweego"
-  ],
-  "license": "MIT",
-  "homepage": "https://github.com/greatsquare0/thy-weaver/tree/main/packages/core",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/greatsquare0/thy-weaver/tree/main/packages/core"
-  },
-  "bugs": "https://github.com/greatsquare0/thy-weaver/issues",
-  "devDependencies": {
-    "@prettier/plugin-oxc": "^0.0.4",
-    "@tsconfig/node22": "^22.0.2",
-    "@types/fs-extra": "^11.0.4",
-    "@types/node": "^24.0.10",
-    "oxlint": "^1.5.0",
-    "prettier": "^3.6.2",
-    "tsdown": "^0.12.9",
-    "typescript": "^5.8.3"
-  },
-  "dependencies": {
-    "@rollup/plugin-url": "^8.0.2",
-    "@swc/core": "^1.12.9",
-    "browserslist": "^4.25.1",
-    "chokidar": "^4.0.3",
-    "commander": "^14.0.0",
-    "deepmerge-ts": "^7.1.5",
-    "fs-extra": "^11.3.0",
-    "h3": "2.0.0-beta.1",
-    "lightningcss": "^1.30.1",
-    "lilconfig": "^3.1.3",
-    "ora": "catalog:",
-    "picocolors": "catalog:",
-    "postcss": "^8.5.6",
-    "postcss-import": "^16.1.1",
-    "postcss-lightningcss": "^1.0.1",
-    "postcss-loader": "^8.1.1",
-    "postcss-scss": "^4.0.9",
-    "rolldown": "1.0.0-beta.24",
-    "rollup-plugin-postcss": "^4.0.2",
-    "rollup-plugin-swc3": "^0.12.1",
-    "sass": "^1.89.2",
-    "tinyglobby": "catalog:",
-    "tweenode": "^0.3.0"
-  }
 }

--- a/packages/core/src/rolldown_setup.ts
+++ b/packages/core/src/rolldown_setup.ts
@@ -6,10 +6,10 @@ import { swc } from "rollup-plugin-swc3";
 //import url, { type RollupUrlOptions } from "@rollup/plugin-url";
 import yaml from '@rollup/plugin-yaml';
 import type {
-    LogLevel,
-    LogOrStringHandler,
-    RolldownOptions,
-    RollupLog,
+  LogLevel,
+  LogOrStringHandler,
+  RolldownOptions,
+  RollupLog,
 } from "rolldown";
 import { withFilter } from 'rolldown/filter';
 
@@ -21,64 +21,64 @@ import { transform } from "@swc/core";
 //const mode = process.env.NODE_ENV || "development";
 
 const onLog = (
-    level: LogLevel,
-    log: RollupLog,
-    defaultHandler: LogOrStringHandler,
+  level: LogLevel,
+  log: RollupLog,
+  defaultHandler: LogOrStringHandler,
 ) => {
-    switch (level) {
-        case "debug":
-            defaultHandler("debug", fancyLogFormater("ROLLDOWN", "DEBUG", log));
-            break;
+  switch (level) {
+    case "debug":
+      defaultHandler("debug", fancyLogFormater("ROLLDOWN", "DEBUG", log));
+      break;
 
-        case "info":
-            defaultHandler("info", fancyLogFormater("ROLLDOWN", "INFO", log));
-            break;
+    case "info":
+      defaultHandler("info", fancyLogFormater("ROLLDOWN", "INFO", log));
+      break;
 
-        case "warn":
-            //Silence circular dependency warning
-            if (log.code !== "CIRCULAR_DEPENDENCY") {
-                defaultHandler("warn", fancyLogFormater("ROLLDOWN", "WARN", log));
-            }
+    case "warn":
+      //Silence circular dependency warning
+      if (log.code !== "CIRCULAR_DEPENDENCY") {
+        defaultHandler("warn", fancyLogFormater("ROLLDOWN", "WARN", log));
+      }
 
-            break;
-        default:
-            break;
-    }
+      break;
+    default:
+      break;
+  }
 };
 
 export const setupRolldown = async () => {
-    const config = await loadConfig();
+  const config = await loadConfig();
 
-    return {
-        onLog,
-        input: resolve(cwd(), config.bundler.filesystem!.projectFiles!.entryPoint!),
-        resolve: {
-            tsconfigFilename: isTS
-                ? resolveToProjectRoot("tsconfig.json")
-                : resolveToProjectRoot("jsconfig.json"),
+  return {
+    onLog,
+    input: resolve(cwd(), config.bundler.filesystem!.projectFiles!.entryPoint!),
+    resolve: {
+      tsconfigFilename: isTS
+        ? resolveToProjectRoot("tsconfig.json")
+        : resolveToProjectRoot("jsconfig.json"),
+    },
+    plugins: [
+      rawImportSupport(),
+      // @ts-expect-error
+      postcss({
+        module: false,
+        plugins: config.bundler.postcss!.plugins,
+        extract: true,
+        //sourceMap: mode === "development",
+        modules: false,
+        autoModules: false,
+        use: {
+          sass: {
+            silenceDeprecations: ["legacy-js-api"],
+          },
         },
-        plugins: [
-            rawImportSupport(),
-            // @ts-expect-error
-            postcss({
-                module: false,
-                plugins: config.bundler.postcss!.plugins,
-                extract: true,
-                //sourceMap: mode === "development",
-                modules: false,
-                autoModules: false,
-                use: {
-                    sass: {
-                        silenceDeprecations: ["legacy-js-api"],
-                    },
-                },
-            }),
-            handleVendorFiles(),
-            swc(config.bundler.swc),
-            withFilter(
-                yaml(),
-                { transform: { id: /\.yaml$/ } }
-            )
-        ],
-    } as RolldownOptions;
+      }),
+      handleVendorFiles(),
+      swc(config.bundler.swc),
+      withFilter(
+        yaml(),
+        { transform: { id: /\.yaml$/ } }
+      )
+    ],
+  } as RolldownOptions;
 };

--- a/packages/core/src/rolldown_setup.ts
+++ b/packages/core/src/rolldown_setup.ts
@@ -4,74 +4,81 @@ import { cwd } from "node:process";
 import postcss from "rollup-plugin-postcss";
 import { swc } from "rollup-plugin-swc3";
 //import url, { type RollupUrlOptions } from "@rollup/plugin-url";
+import yaml from '@rollup/plugin-yaml';
 import type {
-  LogLevel,
-  LogOrStringHandler,
-  RolldownOptions,
-  RollupLog,
+    LogLevel,
+    LogOrStringHandler,
+    RolldownOptions,
+    RollupLog,
 } from "rolldown";
+import { withFilter } from 'rolldown/filter';
 
 import { loadConfig } from "./config/config_handler.ts";
 import { handleVendorFiles, rawImportSupport } from "./rolldown_plugins.ts";
 import { fancyLogFormater, isTS, resolveToProjectRoot } from "./utils.ts";
+import { transform } from "@swc/core";
 
 //const mode = process.env.NODE_ENV || "development";
 
 const onLog = (
-  level: LogLevel,
-  log: RollupLog,
-  defaultHandler: LogOrStringHandler,
+    level: LogLevel,
+    log: RollupLog,
+    defaultHandler: LogOrStringHandler,
 ) => {
-  switch (level) {
-    case "debug":
-      defaultHandler("debug", fancyLogFormater("ROLLDOWN", "DEBUG", log));
-      break;
+    switch (level) {
+        case "debug":
+            defaultHandler("debug", fancyLogFormater("ROLLDOWN", "DEBUG", log));
+            break;
 
-    case "info":
-      defaultHandler("info", fancyLogFormater("ROLLDOWN", "INFO", log));
-      break;
+        case "info":
+            defaultHandler("info", fancyLogFormater("ROLLDOWN", "INFO", log));
+            break;
 
-    case "warn":
-      //Silence circular dependency warning
-      if (log.code !== "CIRCULAR_DEPENDENCY") {
-        defaultHandler("warn", fancyLogFormater("ROLLDOWN", "WARN", log));
-      }
+        case "warn":
+            //Silence circular dependency warning
+            if (log.code !== "CIRCULAR_DEPENDENCY") {
+                defaultHandler("warn", fancyLogFormater("ROLLDOWN", "WARN", log));
+            }
 
-      break;
-    default:
-      break;
-  }
+            break;
+        default:
+            break;
+    }
 };
 
 export const setupRolldown = async () => {
-  const config = await loadConfig();
+    const config = await loadConfig();
 
-  return {
-    onLog,
-    input: resolve(cwd(), config.bundler.filesystem!.projectFiles!.entryPoint!),
-    resolve: {
-      tsconfigFilename: isTS
-        ? resolveToProjectRoot("tsconfig.json")
-        : resolveToProjectRoot("jsconfig.json"),
-    },
-    plugins: [
-      rawImportSupport(),
-      // @ts-expect-error
-      postcss({
-        module: false,
-        plugins: config.bundler.postcss!.plugins,
-        extract: true,
-        //sourceMap: mode === "development",
-        modules: false,
-        autoModules: false,
-        use: {
-          sass: {
-            silenceDeprecations: ["legacy-js-api"],
-          },
+    return {
+        onLog,
+        input: resolve(cwd(), config.bundler.filesystem!.projectFiles!.entryPoint!),
+        resolve: {
+            tsconfigFilename: isTS
+                ? resolveToProjectRoot("tsconfig.json")
+                : resolveToProjectRoot("jsconfig.json"),
         },
-      }),
-      handleVendorFiles(),
-      swc(config.bundler.swc),
-    ],
-  } as RolldownOptions;
+        plugins: [
+            rawImportSupport(),
+            // @ts-expect-error
+            postcss({
+                module: false,
+                plugins: config.bundler.postcss!.plugins,
+                extract: true,
+                //sourceMap: mode === "development",
+                modules: false,
+                autoModules: false,
+                use: {
+                    sass: {
+                        silenceDeprecations: ["legacy-js-api"],
+                    },
+                },
+            }),
+            handleVendorFiles(),
+            swc(config.bundler.swc),
+            withFilter(
+                yaml(),
+                { transform: { id: /\.yaml$/ } }
+            )
+        ],
+    } as RolldownOptions;
 };

--- a/packages/core/src/rolldown_setup.ts
+++ b/packages/core/src/rolldown_setup.ts
@@ -77,7 +77,7 @@ export const setupRolldown = async () => {
       swc(config.bundler.swc),
       withFilter(
         yaml(),
-        { transform: { id: /\.yaml$/ } }
+        { transform: { id: /\.ya?ml$/ } }
       )
     ],
   } as RolldownOptions;


### PR DESCRIPTION
Hi !
Adding a simple yaml import feature for typescript/javascript files.

As always, please do not hesitate to refactor or ask me to refactor anything that is not up to your standards !

## How to test
1. Create a new Thy-Weaver project
2. Add a new yaml file for example `src/assets/app/default_config.yaml`
```yaml
player:
  name: ""
```
3. import it in `src/assets/index.ts` like so
```ts
import defaultConfig from './default_config.yaml';
```
4. now we can play with it, for example adding it into the `State.variables` as a default value
```ts
for (const kvp of Object.entries(defaultConfig)) {
    (State.variables as any)[kvp[0]] = kvp[1];
}
```
5. launch the story in web browser
6. notice the variable assignment in the web browser console (`Sugarcube.State.variables`)

## Notes
I noticed `postcss` plugins are passed in `packages/core/src/rolldown_setup.ts` from the config file. An alternative could be to allow for any plugin in the config file to be passed.